### PR TITLE
Fix: Enable native scroll capture for results page

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -216,3 +216,7 @@ body {
 .theme-lofi {
   background: linear-gradient(135deg, #89f7fe, #66a6ff);
 }
+
+body.wrapped-active {
+  overflow-y: auto;
+}

--- a/components/WrappedResult.module.css
+++ b/components/WrappedResult.module.css
@@ -1,12 +1,7 @@
 .wrappedContainer {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
     color: white;
-    overflow-y: auto;
-    z-index: 100;
+    padding-top: 4rem;
+    padding-bottom: 4rem;
 }
 
 .content {

--- a/components/WrappedResult.tsx
+++ b/components/WrappedResult.tsx
@@ -54,8 +54,18 @@ const WrappedResult: React.FC<WrappedResultProps> = ({ data, onClose, onShare })
     setActiveTheme(isSufficient ? 'theme-sunny-day' : 'theme-starry-night');
   }, [isSufficient]);
 
+  useEffect(() => {
+    const originalBodyClassName = document.body.className;
+    if (activeTheme) {
+      document.body.className = `wrapped-active ${activeTheme}`;
+    }
+    return () => {
+      document.body.className = originalBodyClassName;
+    };
+  }, [activeTheme]);
+
   return (
-    <div className={`${styles.wrappedContainer} ${activeTheme}`}>
+    <div className={styles.wrappedContainer}>
       <div className={styles.menuContainer}>
         <button onClick={() => setIsMenuOpen(!isMenuOpen)} className={styles.menuButton}>
           <MoreHorizontal size={24} />


### PR DESCRIPTION
The native "Scroll Capture" feature on mobile devices was not working for the results page. This was because the page was using a `position: fixed` container with its own scrollbar, which prevents the OS from detecting the full scrollable content.

This commit fixes the issue by:
- Removing the fixed positioning and overflow from the `.wrappedContainer`.
- Applying the theme and `overflow-y: auto` to the `<body>` element when the results page is active.
- Storing and restoring the original body classes to prevent theming issues.

These changes make the main document body the scrollable element, which allows the native "Scroll Capture" feature to work as expected.