### PR TITLE
Fix: Theme not changing in wrapped result

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import Header from '@/components/Header';
 import LandingPage from '@/components/LandingPage';
 import RetirementForm from '@/components/RetirementForm';
+import { WrappedThemeProvider } from '@/contexts/WrappedThemeContext';
 import ResultsPage from '@/components/ResultsPage';
 import ShareModal from '@/components/ShareModal';
 import DonationModal from '@/components/DonationModal';
@@ -92,11 +93,13 @@ export default function Home() {
       )}
       
       {currentView === 'results' && formData && (
-        <ResultsPage 
-          data={formData}
-          onClose={handleResultsClose}
-          onShare={handleShare}
-        />
+        <WrappedThemeProvider>
+          <ResultsPage
+            data={formData}
+            onClose={handleResultsClose}
+            onShare={handleShare}
+          />
+        </WrappedThemeProvider>
       )}
 
       <ShareModal

--- a/components/ThemeModal.tsx
+++ b/components/ThemeModal.tsx
@@ -2,17 +2,24 @@
 
 import { X } from 'lucide-react';
 import React from 'react';
+import { useWrappedTheme } from '@/contexts/WrappedThemeContext';
 
 interface ThemeModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSelectTheme: (theme: string) => void;
 }
 
-const ThemeModal: React.FC<ThemeModalProps> = ({ isOpen, onClose, onSelectTheme }) => {
+const ThemeModal: React.FC<ThemeModalProps> = ({ isOpen, onClose }) => {
+  const { setTheme } = useWrappedTheme();
+
   if (!isOpen) {
     return null;
   }
+
+  const handleSelectTheme = (theme: string) => {
+    setTheme(theme);
+    onClose();
+  };
 
   return (
     <div className="fixed inset-0 z-[150] flex items-center justify-center modal-backdrop">
@@ -30,7 +37,7 @@ const ThemeModal: React.FC<ThemeModalProps> = ({ isOpen, onClose, onSelectTheme 
           {themes.map((theme) => (
             <button
               key={theme.name}
-              onClick={() => onSelectTheme(theme.class)}
+              onClick={() => handleSelectTheme(theme.class)}
               className={`w-full h-24 rounded-lg flex items-center justify-center text-white font-bold text-lg shadow-md transition-transform transform hover:scale-105 ${theme.class}`}
             >
               {theme.name}

--- a/components/WrappedResult.tsx
+++ b/components/WrappedResult.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useLanguage } from '@/contexts/LanguageContext';
+import { useWrappedTheme } from '@/contexts/WrappedThemeContext';
 import styles from './WrappedResult.module.css';
 import { X, MoreHorizontal, Pencil, Share2 } from 'lucide-react';
 import ThemeModal from './ThemeModal';
@@ -23,12 +24,12 @@ interface WrappedResultProps {
 
 const WrappedResult: React.FC<WrappedResultProps> = ({ data, onClose, onShare }) => {
   const { t, language } = useLanguage();
-  const [activeTheme, setActiveTheme] = useState('');
+  const { theme, setTheme } = useWrappedTheme();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isThemeModalOpen, setIsThemeModalOpen] = useState(false);
 
-  const handleThemeSelect = (theme: string) => {
-    setActiveTheme(theme);
+  const handleThemeSelect = (selectedTheme: string) => {
+    setTheme(selectedTheme);
     setIsThemeModalOpen(false);
   };
 
@@ -51,18 +52,21 @@ const WrappedResult: React.FC<WrappedResultProps> = ({ data, onClose, onShare })
 
   useEffect(() => {
     // Set default theme based on results
-    setActiveTheme(isSufficient ? 'theme-sunny-day' : 'theme-starry-night');
-  }, [isSufficient]);
+    setTheme(isSufficient ? 'theme-sunny-day' : 'theme-starry-night');
+  }, [isSufficient, setTheme]);
 
   useEffect(() => {
-    const originalBodyClassName = document.body.className;
-    if (activeTheme) {
-      document.body.className = `wrapped-active ${activeTheme}`;
+    const body = document.body;
+    const originalClasses = body.className;
+
+    if (theme) {
+      body.className = `wrapped-active ${theme}`;
     }
+
     return () => {
-      document.body.className = originalBodyClassName;
+      body.className = originalClasses;
     };
-  }, [activeTheme]);
+  }, [theme]);
 
   return (
     <div className={styles.wrappedContainer}>

--- a/contexts/WrappedThemeContext.tsx
+++ b/contexts/WrappedThemeContext.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+interface WrappedThemeContextType {
+  theme: string;
+  setTheme: (theme: string) => void;
+}
+
+const WrappedThemeContext = createContext<WrappedThemeContextType | undefined>(undefined);
+
+export function WrappedThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState('');
+
+  return (
+    <WrappedThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </WrappedThemeContext.Provider>
+  );
+}
+
+export function useWrappedTheme() {
+  const context = useContext(WrappedThemeContext);
+  if (context === undefined) {
+    throw new Error('useWrappedTheme must be used within a WrappedThemeProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
This commit fixes a bug where the theme would not change when selected in the theme modal on the wrapped result page.

The issue was caused by the theme state being managed locally within the `WrappedResult` component, which was not shared with the `ThemeModal`.

To fix this, a new `WrappedThemeContext` has been introduced to manage the theme state globally for the wrapped result page. The `WrappedResult` and `ThemeModal` components have been refactored to use this new context, ensuring that theme changes are correctly reflected.