### PR TITLE
fix(theme): Use classList to update theme in WrappedResult

### DIFF
--- a/components/WrappedResult.tsx
+++ b/components/WrappedResult.tsx
@@ -55,12 +55,18 @@ const WrappedResult: React.FC<WrappedResultProps> = ({ data, onClose, onShare })
   }, [isSufficient]);
 
   useEffect(() => {
-    const originalBodyClassName = document.body.className;
+    const body = document.body;
+    body.classList.add('wrapped-active');
+
     if (activeTheme) {
-      document.body.className = `wrapped-active ${activeTheme}`;
+      body.classList.add(activeTheme);
     }
+
     return () => {
-      document.body.className = originalBodyClassName;
+      body.classList.remove('wrapped-active');
+      if (activeTheme) {
+        body.classList.remove(activeTheme);
+      }
     };
   }, [activeTheme]);
 


### PR DESCRIPTION
The previous implementation overwrote the entire `document.body.className` string, which could lead to conflicts with other scripts and libraries that also modify the body's classes.

This commit refactors the theme-switching logic in `WrappedResult.tsx` to use `document.body.classList.add()` and `document.body.classList.remove()`. This ensures that theme classes are managed correctly without interfering with other classes on the body element, fixing the bug where the theme would not update correctly after the initial theme was set.