### PR TITLE
Fix: Theme not applying due to CSS specificity

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -198,22 +198,22 @@ body {
 }
 
 /* Dynamic Theme Backgrounds */
-.theme-sunny-day {
+body.theme-sunny-day {
   background: linear-gradient(135deg, #ffc371, #ff5f6d);
 }
-.theme-starry-night {
+body.theme-starry-night {
   background: linear-gradient(135deg, #2c3e50, #4ca1af);
 }
-.theme-party {
+body.theme-party {
   background: linear-gradient(135deg, #ff00cc, #333399);
 }
-.theme-focused {
+body.theme-focused {
   background: linear-gradient(135deg, #2193b0, #6dd5ed);
 }
-.theme-retro-pop {
+body.theme-retro-pop {
   background: linear-gradient(135deg, #f953c6, #b91d73);
 }
-.theme-lofi {
+body.theme-lofi {
   background: linear-gradient(135deg, #89f7fe, #66a6ff);
 }
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -10,7 +10,15 @@ interface HeaderProps {
 
 export default function Header({ onDonationClick }: HeaderProps) {
   const { language, setLanguage, t } = useLanguage();
-  const { theme, toggleTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
+
+  const toggleTheme = () => {
+    // Toggle between a default light and dark theme
+    const newTheme = theme === 'theme-sunny-day' ? 'theme-starry-night' : 'theme-sunny-day';
+    setTheme(newTheme);
+  };
+
+  const isLightTheme = theme === 'theme-sunny-day';
 
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -39,9 +47,9 @@ export default function Header({ onDonationClick }: HeaderProps) {
           <button
             onClick={toggleTheme}
             className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-            title={theme === 'light' ? t('common.darkMode') : t('common.lightMode')}
+            title={isLightTheme ? t('common.darkMode') : t('common.lightMode')}
           >
-            {theme === 'light' ? <Moon className="w-5 h-5" /> : <Sun className="w-5 h-5" />}
+            {isLightTheme ? <Moon className="w-5 h-5" /> : <Sun className="w-5 h-5" />}
           </button>
 
           {/* Donation Button */}

--- a/components/ThemeModal.tsx
+++ b/components/ThemeModal.tsx
@@ -2,17 +2,24 @@
 
 import { X } from 'lucide-react';
 import React from 'react';
+import { useTheme } from '@/contexts/ThemeContext';
 
 interface ThemeModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSelectTheme: (theme: string) => void;
 }
 
-const ThemeModal: React.FC<ThemeModalProps> = ({ isOpen, onClose, onSelectTheme }) => {
+const ThemeModal: React.FC<ThemeModalProps> = ({ isOpen, onClose }) => {
+  const { setTheme } = useTheme();
+
   if (!isOpen) {
     return null;
   }
+
+  const handleSelectTheme = (themeClass: string) => {
+    setTheme(themeClass);
+    onClose();
+  };
 
   return (
     <div className="fixed inset-0 z-[150] flex items-center justify-center modal-backdrop">
@@ -30,7 +37,7 @@ const ThemeModal: React.FC<ThemeModalProps> = ({ isOpen, onClose, onSelectTheme 
           {themes.map((theme) => (
             <button
               key={theme.name}
-              onClick={() => onSelectTheme(theme.class)}
+              onClick={() => handleSelectTheme(theme.class)}
               className={`w-full h-24 rounded-lg flex items-center justify-center text-white font-bold text-lg shadow-md transition-transform transform hover:scale-105 ${theme.class}`}
             >
               {theme.name}

--- a/components/WrappedResult.tsx
+++ b/components/WrappedResult.tsx
@@ -3,6 +3,7 @@ import { useLanguage } from '@/contexts/LanguageContext';
 import styles from './WrappedResult.module.css';
 import { X, MoreHorizontal, Pencil, Share2 } from 'lucide-react';
 import ThemeModal from './ThemeModal';
+import { useTheme } from '@/contexts/ThemeContext';
 
 interface FormData {
   name: string;
@@ -23,14 +24,9 @@ interface WrappedResultProps {
 
 const WrappedResult: React.FC<WrappedResultProps> = ({ data, onClose, onShare }) => {
   const { t, language } = useLanguage();
-  const [activeTheme, setActiveTheme] = useState('');
+  const { setTheme } = useTheme();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isThemeModalOpen, setIsThemeModalOpen] = useState(false);
-
-  const handleThemeSelect = (theme: string) => {
-    setActiveTheme(theme);
-    setIsThemeModalOpen(false);
-  };
 
   const formatNumber = (num: number) => {
     return new Intl.NumberFormat(language === 'th' ? 'th-TH' : 'en-US').format(num);
@@ -51,24 +47,17 @@ const WrappedResult: React.FC<WrappedResultProps> = ({ data, onClose, onShare })
 
   useEffect(() => {
     // Set default theme based on results
-    setActiveTheme(isSufficient ? 'theme-sunny-day' : 'theme-starry-night');
-  }, [isSufficient]);
+    setTheme(isSufficient ? 'theme-sunny-day' : 'theme-starry-night');
+  }, [isSufficient, setTheme]);
 
   useEffect(() => {
     const body = document.body;
     body.classList.add('wrapped-active');
 
-    if (activeTheme) {
-      body.classList.add(activeTheme);
-    }
-
     return () => {
       body.classList.remove('wrapped-active');
-      if (activeTheme) {
-        body.classList.remove(activeTheme);
-      }
     };
-  }, [activeTheme]);
+  }, []);
 
   return (
     <div className={styles.wrappedContainer}>
@@ -159,7 +148,6 @@ const WrappedResult: React.FC<WrappedResultProps> = ({ data, onClose, onShare })
       <ThemeModal
         isOpen={isThemeModalOpen}
         onClose={() => setIsThemeModalOpen(false)}
-        onSelectTheme={handleThemeSelect}
       />
     </div>
   );

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -2,35 +2,38 @@
 
 import React, { createContext, useContext, useState, useEffect } from 'react';
 
-type Theme = 'light' | 'dark';
-
 interface ThemeContextType {
-  theme: Theme;
-  toggleTheme: () => void;
+  theme: string;
+  setTheme: (theme: string) => void;
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<Theme>('light');
+  const [theme, setTheme] = useState('theme-sunny-day'); // Default theme
 
   useEffect(() => {
-    const saved = localStorage.getItem('theme') as Theme;
-    if (saved && (saved === 'light' || saved === 'dark')) {
-      setTheme(saved);
-      document.documentElement.classList.toggle('dark', saved === 'dark');
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme) {
+      setTheme(savedTheme);
     }
   }, []);
 
-  const toggleTheme = () => {
-    const newTheme = theme === 'light' ? 'dark' : 'light';
-    setTheme(newTheme);
-    localStorage.setItem('theme', newTheme);
-    document.documentElement.classList.toggle('dark', newTheme === 'dark');
-  };
+  useEffect(() => {
+    const body = document.body;
+    // Remove any existing theme classes
+    const themes = ['theme-sunny-day', 'theme-starry-night', 'theme-party', 'theme-focused', 'theme-retro-pop', 'theme-lofi'];
+    themes.forEach(t => body.classList.remove(t));
+
+    // Add the new theme class
+    if (theme) {
+      body.classList.add(theme);
+      localStorage.setItem('theme', theme);
+    }
+  }, [theme]);
 
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+    <ThemeContext.Provider value={{ theme, setTheme }}>
       {children}
     </ThemeContext.Provider>
   );


### PR DESCRIPTION
Increased the specificity of the theme selectors in `globals.css` by prepending `body` to each theme class. This ensures that the theme backgrounds correctly override the base styles.