### PR TITLE
Fix: Correct theme selection and application

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -198,22 +198,22 @@ body {
 }
 
 /* Dynamic Theme Backgrounds */
-body.theme-sunny-day {
+html.theme-sunny-day {
   background: linear-gradient(135deg, #ffc371, #ff5f6d);
 }
-body.theme-starry-night {
+html.theme-starry-night {
   background: linear-gradient(135deg, #2c3e50, #4ca1af);
 }
-body.theme-party {
+html.theme-party {
   background: linear-gradient(135deg, #ff00cc, #333399);
 }
-body.theme-focused {
+html.theme-focused {
   background: linear-gradient(135deg, #2193b0, #6dd5ed);
 }
-body.theme-retro-pop {
+html.theme-retro-pop {
   background: linear-gradient(135deg, #f953c6, #b91d73);
 }
-body.theme-lofi {
+html.theme-lofi {
   background: linear-gradient(135deg, #89f7fe, #66a6ff);
 }
 


### PR DESCRIPTION
This commit provides a complete fix for the theme selection functionality.

The theme class is now applied to the `html` element, and the corresponding CSS in `app/globals.css` has been updated to target `html` instead of `body`. This ensures that theme styles are applied correctly and globally.

Additionally, the theme toggle logic in the header has been corrected, and an issue where the theme was being overridden on the results page has been resolved.